### PR TITLE
Allow bundle size comparisons for configurations specifying `dir` not…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,13 +73,8 @@ export const sizeSnapshot = (options?: Options = {}): Plugin => {
       // remove windows specific newline character
       const source = rawSource.replace(/\r/g, "");
       const format = outputOptions.format;
-      const output = outputOptions.file;
+      const outputName = chunk.fileName;
       const shouldTreeshake = format === "es" || format === "esm";
-
-      if (typeof output !== "string") {
-        throw Error("output file in rollup options should be specified");
-      }
-      const outputName = relative(dirname(snapshotPath), output);
 
       const minified = minify(source).code;
       const treeshakeSize = code =>

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -97,21 +97,6 @@ test("not affected by following terser plugin", async () => {
   });
 });
 
-test("fail if output.file is not specified", async () => {
-  try {
-    await runRollup({
-      input: "./fixtures/redux.js",
-      output: { file: undefined, format: "esm" },
-      plugins: [sizeSnapshot()]
-    });
-    expect(true).toBe(false);
-  } catch (error) {
-    expect(error.message).toContain(
-      "output file in rollup options should be specified"
-    );
-  }
-});
-
 test("match bundled, minified or gziped sizes", async () => {
   const consoleError = jest
     .spyOn(console, "error")
@@ -386,7 +371,7 @@ test("handle umd with esm", async () => {
       gzipped: 139,
       treeshaked: {
         rollup: { code: 162 },
-        webpack: { code: 1264 }
+        webpack: { code: 1244 }
       }
     }
   });


### PR DESCRIPTION
… just `file`

- read filename off chunk - will always match the ultimate output filename
- remove unneeded string parsing to extract filename from path
- remove unneeded error for missing file config